### PR TITLE
[fix] Call create_nodes_collections

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -191,13 +191,6 @@ exports.sourceNodes = async ({
         })
       }
 
-      if (locales && locales.length > 0) {
-        for (const locale of locales) {
-          await create_nodes_collections(locale);
-        }
-      } else {
-        await create_nodes_collections(null)
-      }
     }
   }
 
@@ -270,9 +263,11 @@ exports.sourceNodes = async ({
 
   if (locales && locales.length > 0) {
     for (const locale of locales) {
+      await create_nodes_collections(locale);
       await fetch_pages(locale);
     }
   } else {
+    await create_nodes_collections(null);
     await fetch_pages(null);
   }
 


### PR DESCRIPTION
This fixes an error introduced by #15.  The block that calls `create_nodes_collections()` is inside of the function body, so the collections are never created.  Having that block inside of the function body not only fails to create the collection nodes, but it also causes an endless recursion if the function does get called somewhere else.

I've removed that block from the function body, and integrated it into the same condition at the end of `sourceNodes()`.

I'm not very familiar with ButterCMS, so I can't be sure if this causes any other unforeseen issues.  I can only say that this fixes the errors I was having on a project I'm working on.