### PR TITLE
Add preview support for pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-source-buttercms",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Gatsby source plugin for building websites using ButterCMS as a data source",
   "keywords": [
     "gatsby",

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -206,6 +206,10 @@ exports.sourceNodes = async ({
       params.locale = locale
     }
 
+    if (preview) {
+      params.preview = preview
+    }
+
     pageTypes.push('*');
 
     try {


### PR DESCRIPTION
At the moment `fetch_pages` function doesn't make use of `preview` option from the configuration. This PR adds this missing functionality.